### PR TITLE
Hotfix/add-_id-to-responses

### DIFF
--- a/pkg/controllers/controller.go
+++ b/pkg/controllers/controller.go
@@ -21,10 +21,11 @@ func PostSignUp(c *fiber.Ctx) error {
 	hashPassword := utils.GeneratePassword(u.Password)
 
 	createdUser := signup.NewUser(u.Email, hashPassword, u.Name)
-	responseUser := signup.NewUser_SignUp(createdUser.Email, createdUser.Name)
+	responseUser := signup.NewUser_SignUp(createdUser.Email, createdUser.Name, "")
 
 	err := mgm.Coll(createdUser).Create(createdUser)
 
+	responseUser.Id = createdUser.ID.Hex()
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(err)
 	}
@@ -56,7 +57,7 @@ func PostSignIn(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(err)
 	}
 
-	responseUser := signup.NewUser_SignUp(dbUser.Email, dbUser.Name)
+	responseUser := signup.NewUser_SignUp(dbUser.Email, dbUser.Name, dbUser.ID.Hex())
 
 	fmt.Println("Successfully logged user", dbUser.Email)
 

--- a/pkg/models/user_model.go
+++ b/pkg/models/user_model.go
@@ -18,4 +18,5 @@ type User_SignUp_Request struct {
 type User_SignUp_Response struct {
 	Email string `db:"email" json:"email" validate:"required,email,lte=255"`
 	Name  string `db:"name" json:"name" validate:"lte=255"`
+	Id    string `json:"_id,omitempty" validate:"lte=255"`
 }

--- a/pkg/services/sign_up.go
+++ b/pkg/services/sign_up.go
@@ -2,10 +2,11 @@ package signup
 
 import "auth-service/pkg/models"
 
-func NewUser_SignUp(email string, name string) *models.User_SignUp_Response {
+func NewUser_SignUp(email string, name string, id string) *models.User_SignUp_Response {
 	return &models.User_SignUp_Response{
 		Email: email,
 		Name:  name,
+		Id:    id,
 	}
 }
 


### PR DESCRIPTION
Acá los cambios para cerrar los issues 7 y 8. Ya documenté las requests en Postman. 
Te comento que guardé los valores importantes de las requests en variables globales de postma (así estarán disponibles para todo el workspace y se podrán reusar para el api-gateway y el resto de microservicios)

* _id -> USER_ID
* Authorization -> ACCESS_TOKEN
